### PR TITLE
Fix the logo image URL.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,14 +13,14 @@
 
   <!-- GENERIC META PROPERTIES -->
     <meta name="url"   content="https://sketchup.github.io/sketchup-extension-ux-guidelines/" />
-    <meta name="image" content="https://sketchup.github.io/assets/SketchUp-logo.svg" />
+    <meta name="image" content="https://sketchup.github.io/sketchup-extension-ux-guidelines/assets/SketchUp-logo.svg" />
     <meta name="title" content="SketchUp Extension UX Guidelines" />
     <meta name="name"  content="SketchUp Extension UX Guidelines" />
     <meta name="description" content="The purpose of these guidelines is to help developers design extensions that closer align with SketchUp and to create an improved and unified experience for the end user." />
   <!-- OPEN GRAPH META PROPERTIES -->
     <meta property="og:site_name" content="SketchUp Extension UX Guidelines" />
     <meta property="og:type"      content="website" />
-    <meta property="og:image"     content="https://sketchup.github.io/assets/SketchUp-logo.svg" />
+    <meta property="og:image"     content="https://sketchup.github.io/sketchup-extension-ux-guidelines/assets/SketchUp-logo.svg" />
     <meta property="og:image:width"  content="60" />
     <meta property="og:image:height" content="60" />
     <meta property="og:title"     content="SketchUp Extension UX Guidelines" />
@@ -31,7 +31,7 @@
     <meta name="twitter:site"  content="@sketchup" />
     <meta name="twitter:title" content="SketchUp Extension UX Guidelines" />
     <meta name="twitter:description" content="The purpose of these guidelines is to help developers design extensions that closer align with SketchUp and to create an improved and unified experience for the end user." />
-    <meta name="twitter:image:src"   content="https://sketchup.github.io/assets/SketchUp-logo.svg?s=120" />
+    <meta name="twitter:image:src"   content="https://sketchup.github.io/sketchup-extension-ux-guidelines/assets/SketchUp-logo.svg?s=120" />
     <meta name="twitter:url"   content="https://sketchup.github.io/sketchup-extension-ux-guidelines/" />
 
   <!-- STYLESHEETS -->


### PR DESCRIPTION
Need to have the correct Git Pages repository in the URL.
(Because duh, there is no repo named "assets".)